### PR TITLE
Validate learned domain changes

### DIFF
--- a/experiments/basic_experiment_runner.py
+++ b/experiments/basic_experiment_runner.py
@@ -141,8 +141,10 @@ class OfflineBasicExperimentRunner:
             learned_model, learning_report = self._apply_learning_algorithm(partial_domain, allowed_observations, test_set_dir_path)
 
             self.learning_statistics_manager.add_to_action_stats(allowed_observations, learned_model, learning_report)
+
             learned_domain_path = self.validate_learned_domain(
-                allowed_observations, learned_model, test_set_dir_path, fold_num, learning_report["learning_time"]
+                self._learning_algorithm.name, allowed_observations, learned_model, test_set_dir_path,
+                fold_num, float(learning_report["learning_time"])
             )
 
         self.semantic_performance_calc.calculate_performance(learned_domain_path, len(allowed_observations))
@@ -199,10 +201,12 @@ class OfflineBasicExperimentRunner:
         )
 
     def validate_learned_domain(
-        self, allowed_observations: List[Observation], learned_model: LearnerDomain, test_set_dir_path: Path, fold_number: int, learning_time: float
+        self, learning_algorithm_name: str, allowed_observations: List[Observation], learned_model: LearnerDomain,
+            test_set_dir_path: Path, fold_number: int, learning_time: float
     ) -> Path:
         """Validates that using the learned domain both the used and the test set problems can be solved.
 
+        :param learning_algorithm_name: the name of the learning algorithm.
         :param allowed_observations: the observations that were used in the learning process.
         :param learned_model: the domain that was learned using POL.
         :param test_set_dir_path: the path to the directory containing the test set problems.
@@ -216,7 +220,7 @@ class OfflineBasicExperimentRunner:
         self.export_learned_domain(
             learned_model,
             domains_backup_dir_path,
-            f"{self._learning_algorithm.name}_fold_{fold_number}_{learned_model.name}" f"_{len(allowed_observations)}_trajectories.pddl",
+            f"{learning_algorithm_name}_fold_{fold_number}_{learned_model.name}" f"_{len(allowed_observations)}_trajectories.pddl",
         )
 
         self.logger.debug("Checking that the test set problems can be solved using the learned domain.")

--- a/experiments/basic_experiment_runner.py
+++ b/experiments/basic_experiment_runner.py
@@ -201,7 +201,7 @@ class OfflineBasicExperimentRunner:
         )
 
     def validate_learned_domain(
-        self, learning_algorithm_name: str, allowed_observations: List[Observation], learned_model: LearnerDomain,
+        self, allowed_observations: List[Observation], learned_model: LearnerDomain,
             test_set_dir_path: Path, fold_number: int, learning_time: float
     ) -> Path:
         """Validates that using the learned domain both the used and the test set problems can be solved.
@@ -220,7 +220,7 @@ class OfflineBasicExperimentRunner:
         self.export_learned_domain(
             learned_model,
             domains_backup_dir_path,
-            f"{learning_algorithm_name}_fold_{fold_number}_{learned_model.name}" f"_{len(allowed_observations)}_trajectories.pddl",
+            f"{self._learning_algorithm.name}_fold_{fold_number}_{learned_model.name}" f"_{len(allowed_observations)}_trajectories.pddl",
         )
 
         self.logger.debug("Checking that the test set problems can be solved using the learned domain.")

--- a/experiments/basic_experiment_runner.py
+++ b/experiments/basic_experiment_runner.py
@@ -143,7 +143,7 @@ class OfflineBasicExperimentRunner:
             self.learning_statistics_manager.add_to_action_stats(allowed_observations, learned_model, learning_report)
 
             learned_domain_path = self.validate_learned_domain(
-                self._learning_algorithm.name, allowed_observations, learned_model, test_set_dir_path,
+                allowed_observations, learned_model, test_set_dir_path,
                 fold_num, float(learning_report["learning_time"])
             )
 
@@ -206,7 +206,6 @@ class OfflineBasicExperimentRunner:
     ) -> Path:
         """Validates that using the learned domain both the used and the test set problems can be solved.
 
-        :param learning_algorithm_name: the name of the learning algorithm.
         :param allowed_observations: the observations that were used in the learning process.
         :param learned_model: the domain that was learned using POL.
         :param test_set_dir_path: the path to the directory containing the test set problems.

--- a/experiments/multi_agent_experiment_runner.py
+++ b/experiments/multi_agent_experiment_runner.py
@@ -99,7 +99,8 @@ class MultiAgentExperimentRunner(OfflineBasicExperimentRunner):
         self.export_learned_domain(
             learned_model, self.working_directory_path / "results_directory",
             f"ma_baseline_domain_{len(allowed_filtered_observations)}_trajectories_fold_{fold_num}.pddl")
-        self.validate_learned_domain(allowed_filtered_observations, learned_model, test_set_dir_path)
+        self.validate_learned_domain("ma_baseline_domain", allowed_filtered_observations, learned_model,
+                                     test_set_dir_path, fold_num, float(learning_report["learning_time"]))
 
     def learn_ma_action_model(
             self, allowed_complete_observations: List[MultiAgentObservation],
@@ -120,7 +121,8 @@ class MultiAgentExperimentRunner(OfflineBasicExperimentRunner):
         self.ma_domain_path = self.working_directory_path / "results_directory" / \
                               f"ma_sam_domain_{len(allowed_complete_observations)}_trajectories_fold_{fold_num}.pddl"
         self.export_learned_domain(learned_model, self.ma_domain_path.parent, self.ma_domain_path.name)
-        self.validate_learned_domain(allowed_complete_observations, learned_model, test_set_dir_path)
+        self.validate_learned_domain(self._learning_algorithm.name, allowed_complete_observations, learned_model,
+                                     test_set_dir_path, fold_num, float(learning_report["learning_time"]))
 
     def run_cross_validation(self) -> None:
         """Runs that cross validation process on the domain's working directory and validates the results."""

--- a/experiments/multi_agent_experiment_runner.py
+++ b/experiments/multi_agent_experiment_runner.py
@@ -91,6 +91,7 @@ class MultiAgentExperimentRunner(OfflineBasicExperimentRunner):
         :param fold_num: the index of the current fold in the cross validation process.
         """
         learner = SAMLearner(partial_domain=partial_domain)
+        self._learning_algorithm = LearningAlgorithmType.sam_learning
         self.domain_validator.learning_algorithm = LearningAlgorithmType.sam_learning
         self.learning_statistics_manager.learning_algorithm = LearningAlgorithmType.sam_learning
         learned_model, learning_report = learner.learn_action_model(allowed_filtered_observations)
@@ -99,7 +100,7 @@ class MultiAgentExperimentRunner(OfflineBasicExperimentRunner):
         self.export_learned_domain(
             learned_model, self.working_directory_path / "results_directory",
             f"ma_baseline_domain_{len(allowed_filtered_observations)}_trajectories_fold_{fold_num}.pddl")
-        self.validate_learned_domain("ma_baseline_domain", allowed_filtered_observations, learned_model,
+        self.validate_learned_domain(allowed_filtered_observations, learned_model,
                                      test_set_dir_path, fold_num, float(learning_report["learning_time"]))
 
     def learn_ma_action_model(
@@ -113,6 +114,7 @@ class MultiAgentExperimentRunner(OfflineBasicExperimentRunner):
         :param fold_num: the index of the current fold in the cross validation process.
         """
         learner = MultiAgentSAM(partial_domain=partial_domain)
+        self._learning_algorithm = LearningAlgorithmType.ma_sam
         self.learning_statistics_manager.learning_algorithm = LearningAlgorithmType.ma_sam
         self.domain_validator.learning_algorithm = LearningAlgorithmType.ma_sam
         learned_model, learning_report = learner.learn_combined_action_model(allowed_complete_observations)
@@ -121,7 +123,7 @@ class MultiAgentExperimentRunner(OfflineBasicExperimentRunner):
         self.ma_domain_path = self.working_directory_path / "results_directory" / \
                               f"ma_sam_domain_{len(allowed_complete_observations)}_trajectories_fold_{fold_num}.pddl"
         self.export_learned_domain(learned_model, self.ma_domain_path.parent, self.ma_domain_path.name)
-        self.validate_learned_domain(self._learning_algorithm.name, allowed_complete_observations, learned_model,
+        self.validate_learned_domain(allowed_complete_observations, learned_model,
                                      test_set_dir_path, fold_num, float(learning_report["learning_time"]))
 
     def run_cross_validation(self) -> None:
@@ -140,6 +142,7 @@ class MultiAgentExperimentRunner(OfflineBasicExperimentRunner):
             self.learning_statistics_manager.clear_statistics()
             self.logger.info(f"Finished learning the action models for the fold {fold_num + 1}.")
 
+        self._learning_algorithm = LearningAlgorithmType.ma_sam
         self.domain_validator.write_complete_joint_statistics()
         self.semantic_performance_calc.export_combined_semantic_performance()
         self.learning_statistics_manager.export_all_folds_action_stats()


### PR DESCRIPTION
1.Passing required arguments. 
2.Extracting name of the algorithm as a parameter as sam uses it in the multi agent experiment as well despite having a different name. This way when it's exporting into domain backup, sam won't override ma-sam files.