### PR TITLE
Refactor domain type usage and add evaluation flag

### DIFF
--- a/experiments/concurrent_execution/parallel_multi_agent_experiment_runner_with_triplets.py
+++ b/experiments/concurrent_execution/parallel_multi_agent_experiment_runner_with_triplets.py
@@ -1,4 +1,5 @@
 """Runs experiments for the numeric model learning algorithms."""
+
 import argparse
 import os
 from pathlib import Path
@@ -52,7 +53,7 @@ class MultiAgentTripletsBasedExperimentRunner(SingleIterationMultiAgentExperimen
             used to solve.
         """
         self.logger.info(f"Executing the experiments on the action triplets instead of the trajectories for the fold - {fold_num}!")
-        self._init_semantic_performance_calculator(fold_num)
+        self._init_semantic_performance_calculator(fold_num, should_include_sam_in_ma_evaluation=True)
         partial_domain = self.read_domain_file(train_set_dir_path)
         complete_train_set: List[MultiAgentObservation] = super().collect_observations(train_set_dir_path, partial_domain)
         triplets_per_experiment = MAX_TRIPLETS_FOR_EXPERIMENT if partial_domain.name != "rover" else ROVERS_TRIPLETS_PER_EXPERIMENT
@@ -66,7 +67,9 @@ class MultiAgentTripletsBasedExperimentRunner(SingleIterationMultiAgentExperimen
             allowed_observations = []
             # create the allowed observations for the SAM learning algorithm
             for observation in transitions_based_training_set:
-                filtered_observation, num_trivial_triplets, num_non_trivial_triplets = self._filter_baseline_single_agent_trajectory(observation)
+                filtered_observation, num_trivial_triplets, num_non_trivial_triplets = self._filter_baseline_single_agent_trajectory(
+                    observation
+                )
                 allowed_observations.append(filtered_observation)
                 num_trivial_action_triplets += num_trivial_triplets
                 num_non_trivial_action_triplets += num_non_trivial_triplets
@@ -99,7 +102,10 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--working_directory_path", required=True, help="The path to the directory where the domain is")
     parser.add_argument("--domain_file_name", required=True, help="the domain file name including the extension")
     parser.add_argument(
-        "--learning_algorithm", required=True, type=int, choices=[1, 7, 25],
+        "--learning_algorithm",
+        required=True,
+        type=int,
+        choices=[1, 7, 25],
     )
     parser.add_argument("--fold_number", required=True, help="The number of the fold to run", type=int)
     parser.add_argument("--debug", required=False, help="Whether in debug mode.", type=bool, default=False)

--- a/sam_learning/learners/ma_sam_plus.py
+++ b/sam_learning/learners/ma_sam_plus.py
@@ -1,4 +1,5 @@
 """Module to learn action models with macro actions from multi-agent trajectories with joint actions."""
+
 from itertools import combinations, chain
 from typing import Dict, List, Tuple, Optional, Set
 
@@ -62,7 +63,7 @@ def generate_supersets_of_actions(action_groups: List[Set[str]]) -> List[Set[str
 
 class MASAMPlus(MultiAgentSAM):
     """Class designated to learning action models with macro actions
-        from multi-agent trajectories with joint actions."""
+    from multi-agent trajectories with joint actions."""
 
     mapping: Dict[str, MappingElement]
 
@@ -113,10 +114,10 @@ class MASAMPlus(MultiAgentSAM):
     def extract_relevant_parameter_groupings(self, action_group_names: List[str]) -> List[PGType]:
         """Extracts relevant parameter groups, that is, the parameters of the actions in the action group.
 
-            Note:
-                This implementation only extracts one such possible parameter groups
+        Note:
+            This implementation only extracts one such possible parameter groups
 
-            :param action_group_names: the names of the actions in the action group.
+        :param action_group_names: the names of the actions in the action group.
         """
         all_param_groups = [
             param_set
@@ -130,7 +131,9 @@ class MASAMPlus(MultiAgentSAM):
 
         return [flattened_groups]
 
-    def extract_effects_for_macro_from_cnf(self, lma_set: Set[LearnerAction], param_grouping: PGType, mapping: BindingType) -> Set[Predicate]:
+    def extract_effects_for_macro_from_cnf(
+        self, lma_set: Set[LearnerAction], param_grouping: PGType, mapping: BindingType
+    ) -> Set[Predicate]:
         """Extract the effects of the macro action containing the input single-agent actions.
 
         :param lma_set: the single agent actions contained in the macro action.
@@ -213,7 +216,7 @@ class MASAMPlus(MultiAgentSAM):
 
     def learn_combined_action_model_with_macro_actions(
         self, observations: List[MultiAgentObservation]
-    ) -> Tuple[LearnerDomain, Dict[str, str], Dict[str, MappingElement]]:
+    ) -> Tuple[Domain, Dict[str, str], Dict[str, MappingElement]]:
         """Learn the SAFE action model from the input multi-agent trajectories.
 
         :param observations: the multi-agent observations.

--- a/statistics/learning_statistics_manager.py
+++ b/statistics/learning_statistics_manager.py
@@ -1,4 +1,5 @@
 """Module to manage the action model learning statistics."""
+
 import csv
 from collections import Counter
 from pathlib import Path
@@ -90,7 +91,9 @@ class LearningStatisticsManager:
         return action_appearance_counter
 
     def _extract_all_preconditions(self, action_name, learned_domain):
-        learned_preconditions = [p.untyped_representation for _, p in learned_domain.actions[action_name].preconditions if isinstance(p, Predicate)]
+        learned_preconditions = [
+            p.untyped_representation for _, p in learned_domain.actions[action_name].preconditions if isinstance(p, Predicate)
+        ]
         ground_truth_preconditions = [
             p.untyped_representation for _, p in self.model_domain.actions[action_name].preconditions if isinstance(p, Predicate)
         ]
@@ -149,7 +152,7 @@ class LearningStatisticsManager:
     def add_to_action_stats(
         self,
         used_observations: List[Union[Observation, MultiAgentObservation]],
-        learned_domain: LearnerDomain,
+        learned_domain: Domain,
         learning_report: Optional[Dict[str, str]] = None,
         policy: NegativePreconditionPolicy = NegativePreconditionPolicy.no_remove,
     ) -> None:
@@ -231,7 +234,9 @@ class LearningStatisticsManager:
         :param fold_number: the number of the currently running fold.
         :param iteration_num: the number of the current iteration.
         """
-        self._export_statistics_data(fold_number, iteration_num, LEARNED_ACTIONS_STATS_COLUMNS, self.action_learning_stats, "action_stats_fold")
+        self._export_statistics_data(
+            fold_number, iteration_num, LEARNED_ACTIONS_STATS_COLUMNS, self.action_learning_stats, "action_stats_fold"
+        )
 
     def export_all_folds_action_stats(self) -> None:
         """Export the statistics collected about the actions."""

--- a/statistics/utils.py
+++ b/statistics/utils.py
@@ -35,6 +35,7 @@ def init_semantic_performance_calculator(
     executing_agents: Optional[List[str]] = None,
     test_set_dir_path: Path = None,
     problem_prefix: str = "pfile",
+    should_include_sam_in_ma_evaluation: bool = False,
 ) -> Union[NumericPerformanceCalculator, SemanticPerformanceCalculator, MASamPerformanceCalculator]:
     """Initializes a numeric performance calculator object.
 
@@ -45,10 +46,12 @@ def init_semantic_performance_calculator(
     :param executing_agents: the agents that are executing the domain.
     :param test_set_dir_path: the path to the directory containing the test set.
     :param problem_prefix: the prefix of the problem files.
+    :param should_include_sam_in_ma_evaluation: whether to include SAM in the multi-agent evaluation.
     :return: the initialized numeric performance calculator object.
     """
     if domain_file_name is None and domain_file_path is None:
         raise ValueError("Either 'domain_file_name' or 'domain_file_path' must be provided.")
+
     domain_path = domain_file_path if domain_file_path is not None else working_directory_path / domain_file_name
     model_domain = partial_domain = DomainParser(domain_path=domain_path, partial_parsing=False).parse_domain()
     observations = []
@@ -68,7 +71,9 @@ def init_semantic_performance_calculator(
             learning_algorithm=learning_algorithm,
         )
 
-    elif learning_algorithm in MULTI_AGENT_ALGORITHMS:
+    elif learning_algorithm in MULTI_AGENT_ALGORITHMS or (
+        learning_algorithm.name == LearningAlgorithmType.sam_learning.name and should_include_sam_in_ma_evaluation
+    ):
         return MASamPerformanceCalculator(
             model_domain=model_domain,
             observations=observations,


### PR DESCRIPTION
Replaces references to LearnerDomain with Domain in experiment runners, statistics manager, and MASAMPlus to standardize domain type usage. Adds should_include_sam_in_ma_evaluation flag to semantic performance calculator initialization for more flexible multi-agent evaluation. Minor formatting and argument handling improvements throughout.